### PR TITLE
absolutize the path of target file

### DIFF
--- a/cmd/hoi/main.go
+++ b/cmd/hoi/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/monochromegane/hoi"
@@ -39,7 +40,11 @@ func main() {
 			os.Exit(1)
 		}
 		// make public
-		hoi.MakePublic(args[0])
+		abspath, patherr := filepath.Abs(args[0])
+		if patherr != nil {
+			os.Exit(1)
+		}
+		hoi.MakePublic(abspath)
 		// run hoi server as a daemon
 		runAsDaemon()
 	}


### PR DESCRIPTION
I fixed the problem in #1.

After this fix, sample of command line log is as following:

```
% pwd
/Users/issm/sandbox/go/hoi
% ./hoi hoi.go
http://192.168.1.154:8081/cn2yll4jrrs5s8c9fslwtucze1rx672e/hoi.go
% tree ~/.hoi
/Users/issm/.hoi
├── conf.json
└── temp_public
    └── cn2yll4jrrs5s8c9fslwtucze1rx672e
        └── hoi.go -> /Users/issm/sandbox/go/hoi/hoi.go

2 directories, 2 files

% curl -I http://192.168.1.154:8081/cn2yll4jrrs5s8c9fslwtucze1rx672e/hoi.go
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 1816
Content-Type: text/plain; charset=utf-8
Last-Modified: Sat, 19 Jul 2014 07:32:04 GMT
Date: Sat, 19 Jul 2014 07:58:19 GMT
```
